### PR TITLE
Unified pluggable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ It supports easy switching between multiple versions of GHC by having a set of c
 * The build directory (cabal `--builddir` parameter). This defaults to `dist/`.
 
 It also provides support for `ide-haskell`'s build target selection by reading and parsing the `.cabal` file and extracting the available targets (it uses a thin `ghcjs`-compiled wrapper around the `Cabal` library to read the .`cabal` file).
+
+## Keybindings
+
+Ide-Haskell-Cabal comes with little pre-specified keybindings, so you will need to specify your own, if you want those.
+
+You can edit Atom keybindings by opening 'Edit → Open Your Keymap'. Here is a template for all commands, provided by ide-haskell-cabal:
+
+```cson
+'atom-workspace':
+  '': 'ide-haskell-cabal:build'
+  '': 'ide-haskell-cabal:set-build-target'
+  '': 'ide-haskell-cabal:clean'
+  '': 'ide-haskell-cabal:test'
+```

--- a/lib/ide-backend.coffee
+++ b/lib/ide-backend.coffee
@@ -16,6 +16,8 @@ class IdeBackend
   constructor: (@upi) ->
     @disposables = new CompositeDisposable
 
+    @buildTarget = {name: 'All'}
+
     @disposables.add @upi.addPanelControl @targetElem = (document.createElement 'ide-haskell-target'),
       events:
         click: ->
@@ -203,14 +205,9 @@ class IdeBackend
       @targetElem.innerText = "#{name}"
 
   setTarget: ->
-    @getTargets().then (targets) =>
+    [cabalRoot, cabalFile] = @findCabalFile @getActiveProjectPath()
+    @parseCabalFile (path.join cabalRoot, cabalFile), (targets) =>
       new TargetListView
         items: targets.targets
         onConfirmed: (@buildTarget) =>
           @showTarget()
-
-  getTargets: ->
-    [cabalRoot, cabalFile] = @findCabalFile @getActiveProjectPath()
-    new Promise (resolve) =>
-      @parseCabalFile (path.join cabalRoot, cabalFile), (cabalParsed) ->
-        resolve cabalParsed

--- a/lib/ide-backend.coffee
+++ b/lib/ide-backend.coffee
@@ -13,10 +13,10 @@ TargetListView = require './views/target-list-view'
 module.exports =
 class IdeBackend
 
-  constructor: (@upi) ->
+  constructor: (@upi, state) ->
     @disposables = new CompositeDisposable
 
-    @buildTarget = {name: 'All'}
+    @buildTarget = state?.target ? {name: 'All'}
 
     @disposables.add @upi.addPanelControl @targetElem = (document.createElement 'ide-haskell-target'),
       events:
@@ -204,10 +204,11 @@ class IdeBackend
     else
       @targetElem.innerText = "#{name}"
 
-  setTarget: ->
+  setTarget: ({onComplete}) ->
     [cabalRoot, cabalFile] = @findCabalFile @getActiveProjectPath()
     @parseCabalFile (path.join cabalRoot, cabalFile), (targets) =>
       new TargetListView
         items: targets.targets
         onConfirmed: (@buildTarget) =>
           @showTarget()
+          onComplete? @buildTarget

--- a/lib/ide-haskell-cabal.coffee
+++ b/lib/ide-haskell-cabal.coffee
@@ -8,13 +8,18 @@ module.exports = IdeHaskellCabal =
   subscriptions: null
 
   activate: (@state) ->
+    @disposables = null
+
+  deactivate: ->
+    @disposables?.dispose?()
+    @disposables = null
 
   serialize: ->
     target: @target
 
-  consumeUPI: (upi) ->
-    disposables = new CompositeDisposable
-    disposables.add upi.disposables
+  consumeUPI: (service) ->
+    upi = service.registerPlugin @disposables = new CompositeDisposable
+    @disposables.add upi.disposables
 
     backend = new IdeBackend(upi, @state)
 
@@ -28,7 +33,7 @@ module.exports = IdeHaskellCabal =
         uriFilter: false
         autoScroll: true
 
-    disposables.add atom.commands.add 'atom-workspace',
+    @disposables.add atom.commands.add 'atom-workspace',
       'ide-haskell-cabal:build': ->
         backend.build()
       'ide-haskell-cabal:clean': ->
@@ -45,7 +50,7 @@ module.exports = IdeHaskellCabal =
         {label: 'Test', command: 'ide-haskell-cabal:test'}
       ]
 
-    disposables
+    @disposables
 
   # Configuration settings
   #

--- a/lib/ide-haskell-cabal.coffee
+++ b/lib/ide-haskell-cabal.coffee
@@ -9,12 +9,14 @@ module.exports = IdeHaskellCabal =
 
   activate: (@state) ->
 
+  serialize: ->
+    target: @target
+
   consumeUPI: (upi) ->
-    console.log "consumeUPI"
     disposables = new CompositeDisposable
     disposables.add upi.disposables
 
-    backend = new IdeBackend(upi)
+    backend = new IdeBackend(upi, @state)
 
     upi.setMessageTypes
       error: {}
@@ -33,8 +35,8 @@ module.exports = IdeHaskellCabal =
         backend.clean()
       'ide-haskell-cabal:test': ->
         backend.test()
-      'ide-haskell-cabal:set-build-target': ->
-        backend.setTarget()
+      'ide-haskell-cabal:set-build-target': =>
+        backend.setTarget onComplete: (@target) =>
 
     upi.setMenu 'Cabal', [
         {label: 'Build Project', command: 'ide-haskell-cabal:build'}

--- a/lib/views/target-list-view.coffee
+++ b/lib/views/target-list-view.coffee
@@ -1,0 +1,34 @@
+{SelectListView} = require 'atom-space-pen-views'
+
+module.exports=
+class TargetListView extends SelectListView
+  initialize: ({@onConfirmed, items}) ->
+    super
+    @panel = atom.workspace.addModalPanel
+      item: this
+      visible: false
+    @addClass 'ide-haskell'
+    @show items
+
+  cancelled: ->
+    @panel.destroy()
+
+  getFilterKey: ->
+    "name"
+
+  show: (list) ->
+    @setItems [{name: 'All', type: ''}].concat list
+    @panel.show()
+    @storeFocusedElement()
+    @focusFilterEditor()
+
+  viewForItem: (tgt) ->
+    "<li>
+      <div class='type'>#{tgt.type}</div>
+      <div class='name'>#{tgt.name}</div>
+    </li>
+    "
+
+  confirmed: (tgt) ->
+    @onConfirmed? tgt
+    @cancel()

--- a/package.json
+++ b/package.json
@@ -15,20 +15,14 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {},
-    "consumedServices": {
+  "dependencies": {
+    "atom-space-pen-views": "^2.0.3"
+  },
+  "consumedServices": {
     "ide-haskell-upi": {
       "description": "Uses ide-haskell's unified pluggable interface",
       "versions": {
         "0.0.1": "consumeUPI"
-      }
-    }
-  },
-  "providedServices": {
-    "haskell-build-backend": {
-      "description": "ide-haskell support for Cabal",
-      "versions": {
-        "0.3.0": "provideIdeBackend"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,14 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {},
+    "consumedServices": {
+    "ide-haskell-upi": {
+      "description": "Uses ide-haskell's unified pluggable interface",
+      "versions": {
+        "0.0.1": "consumeUPI"
+      }
+    }
+  },
   "providedServices": {
     "haskell-build-backend": {
       "description": "ide-haskell support for Cabal",


### PR DESCRIPTION
I figured that to be able to support different backend providers, possibly simultaneously, drastic changes to API would be required. So I looked at what ide-backend and build-backend do at the moment, and devised somewhat of a unified interface.

Most commands/settings/actions are moved to backend provider, while ide-haskell provides a service to display tooltips and messages, react to events (like mouse hover or buffer save), and some utility functions.

This is a major architecture change, although build-backend did work very similarly to this. I will test this branch for a while, and if everything goes well, will merge it. Bear this in mind when developing new backends.
