### PR TITLE
Rudimentary first support for `cabal new-build`

### DIFF
--- a/lib/ide-backend.coffee
+++ b/lib/ide-backend.coffee
@@ -87,6 +87,19 @@ class IdeBackend
         cabalArgs.push target if target? and cmd is 'build'
         CabalProcess ?= require './cabal-process'
         cabalProcess = new CabalProcess 'cabal', cabalArgs, @spawnOpts(cabalRoot), opts
+      else if @buildBuilder is 'cabal-nix'
+        # TODOs:
+        #   * Commands other than 'build'
+        #   * Support for buildDir
+        if cmd is 'build'
+          cabalArgs = ['new-build']
+        else
+          throw new Error("Unsupported command '#{cmd}'")
+
+        target = opts.target.target
+        cabalArgs.push target if target? and cmd is 'build'
+        CabalProcess ?= require './cabal-process'
+        cabalProcess = new CabalProcess 'cabal', cabalArgs, @spawnOpts(cabalRoot), opts
       else if @buildBuilder is 'stack'
         cabalArgs = atom.config.get('ide-haskell-cabal.stack.globalArguments') ? []
         cabalArgs.push cmd
@@ -254,7 +267,7 @@ class IdeBackend
   setBuilder: ({onComplete}) ->
     BuilderListView ?= require './views/builder-list-view'
 
-    builders = [{name: 'cabal'}, {name: 'stack'}]
+    builders = [{name: 'cabal'}, {name: 'stack'}, {name: 'cabal-nix'}]
 
     new BuilderListView
       items: builders


### PR DESCRIPTION
This provides a new builder `cabal-nix` (as a third choice to `cabal`,
`stack`). Currently the only command support is `build` (which corresponds to
`cabal new-build`).

@lierdakil Not sure if you want to merge this now or make this more feature-complete. That said, given that `cabal new-build` is itself a technology preview, feature-complete is unlikely to happen anyway. Up to you. 
